### PR TITLE
Add basic checks on the deserialized record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Basic checks on PNDA message after deserialization
+
 ## [0.1.1] 2016-09-13
 ### Changes
 - Enhanced CI support

--- a/gobblin-PNDA/src/main/java/gobblin/pnda/PNDAConverter.java
+++ b/gobblin-PNDA/src/main/java/gobblin/pnda/PNDAConverter.java
@@ -149,7 +149,21 @@ public class PNDAConverter extends Converter<String,
     Decoder binaryDecoder = DecoderFactory.get().binaryDecoder(inputRecord, null);
     try {
       GenericRecord record = reader.read(null, binaryDecoder);
-      return new SingleRecordIterable<>(record);
+
+      /* Do some basic checking on the deserialized AVRO fragment */
+      if (((long) record.get("timestamp")) <= 0) {
+        writeErrorData(inputRecord, "'timestamp' field cannot be negative");
+        return new EmptyIterable<>();
+      } else if (((org.apache.avro.util.Utf8) record.get("src")).length() == 0) {
+        writeErrorData(inputRecord, "'src' field cannot be empty");
+        return new EmptyIterable<>();
+      } else if (((java.nio.Buffer) record.get("rawdata")).limit() == 0) {
+        writeErrorData(inputRecord, "'rawdata' field cannot be empty");
+        return new EmptyIterable<>();
+      } else {
+        /* It looks like a valid PNDA record */
+        return new SingleRecordIterable<>(record);
+      }
     } catch (IOException | AvroRuntimeException error) {
       writeErrorData(inputRecord, "Unable to deserialize data");
       return new EmptyIterable<>();

--- a/gobblin-PNDA/src/main/java/gobblin/pnda/PNDAKiteWriter.java
+++ b/gobblin-PNDA/src/main/java/gobblin/pnda/PNDAKiteWriter.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 
 import org.apache.avro.generic.GenericRecord;
 
+import com.google.common.base.Preconditions;
+
 import org.kitesdk.data.Dataset;
 import org.kitesdk.data.DatasetWriter;
 
@@ -64,6 +66,8 @@ public class PNDAKiteWriter implements DataWriter<GenericRecord> {
      */
     @Override
     public final void write(GenericRecord record) throws IOException {
+        Preconditions.checkNotNull(record);
+
         this.writer.write(record);
         this.recordsWritten++;
     }


### PR DESCRIPTION
This is needed as some non PNDA messages can be correctly deserialized
to valid PNDA messages. For exemple it prevents the internal kafka
'__consumer_offsets' topic from being ingested.

PNDA-2154
