### PR TITLE
Disable data-management-tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,6 @@ else
 fi
 
 mkdir -p pnda-build
-./gradlew clean build -Pversion=${VERSION} -PhadoopVersion=${HADOOP_VERSION} -PexcludeHadoopDeps -PexcludeHiveDeps -x gobblin-core:test
+./gradlew clean build -Pversion=${VERSION} -PhadoopVersion=${HADOOP_VERSION} -PexcludeHadoopDeps -PexcludeHiveDeps -x gobblin-core:test -x gobblin-data-management:test
 mv gobblin-distribution-${VERSION}.tar.gz pnda-build/
 sha512sum pnda-build/gobblin-distribution-${VERSION}.tar.gz > pnda-build/gobblin-distribution-${VERSION}.tar.gz.sha512.txt


### PR DESCRIPTION
These cause unwanted side effects, in particular their use of
the Trash classes causes the $HOME directory to be given 777
permissions.