### PR TITLE
Don't run tests by default

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,14 @@
 #
 # Please check pnda-build/ for the build products
 
+
+# The Gobblin tests are very thorough, resource intensive and are likely to fail
+# on unsuitable build platforms. Since we're typically building to a known-good label
+# default the execution of these tests to 'off'. Developers should renable.
+EXCLUDES="-x test"
+
 set -e
+set -x
 
 export LC_ALL=en_US.utf8
 HADOOP_VERSION=2.6.0-cdh5.9.0
@@ -33,6 +40,6 @@ else
 fi
 
 mkdir -p pnda-build
-./gradlew clean build -Pversion="${VERSION}" -PhadoopVersion="${HADOOP_VERSION}" -PexcludeHadoopDeps -PexcludeHiveDeps -x gobblin-core:test -x gobblin-data-management:test
+./gradlew clean build -Pversion="${VERSION}" -PhadoopVersion="${HADOOP_VERSION}" -PexcludeHadoopDeps -PexcludeHiveDeps ${EXCLUDES}
 mv gobblin-distribution-${VERSION}.tar.gz pnda-build/
 sha512sum pnda-build/gobblin-distribution-${VERSION}.tar.gz > pnda-build/gobblin-distribution-${VERSION}.tar.gz.sha512.txt


### PR DESCRIPTION
Given the main use case is to build to a known good label it adds very little to run these very extensive and resource intensive tests. However, they should still be used in development. Hence, default to 'off' and provide obvious option to switch back on.