### PR TITLE
PNDA-3304: Remove javadoc generation in all subprojects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+- PNDA-3304: Remove javadoc generation in all subprojects.
+
 ## [0.1.5] 2017-07-04
 ### Changed
 - PNDA-3103: Accept any JDK1.8 to build

--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,17 @@ else
     echo "OK"
 fi
 
+# The javadoc generation isn't able to take the proxy setting into consideration,
+# so we disable the generation in all submodules for now.
+if ! fgrep -q 'tasks.withType(Javadoc).all { enabled = false }' build.gradle; then
+cat >> build.gradle << EOF
+
+subprojects {
+  tasks.withType(Javadoc).all { enabled = false }
+}
+EOF
+fi
+
 mkdir -p pnda-build
 ./gradlew clean build -Pversion="${VERSION}" -PhadoopVersion="${HADOOP_VERSION}" -PexcludeHadoopDeps -PexcludeHiveDeps ${EXCLUDES}
 mv gobblin-distribution-${VERSION}.tar.gz pnda-build/


### PR DESCRIPTION
The javadoc generation fails when taking place behind non-transparent proxy.
This patch removes the javadoc generation from all the sub projects allowing the build to take place behind a non-transparent proxy.